### PR TITLE
Include notes about required files in proto_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ So you can reuse existing data definitions in .proto for BigQuery with this plug
 The generated JSON schema files are suffixed with `.schema` and their base names are named
 after their package names and `bq_table_name` options.
 
+If you do not already have the standard google protobuf libraries in your `proto_path`, you'll need to specify them directly on the command line (and potentially need to copy `bq_schema.proto` into a proto_path directory as well), like this:
+
+```sh
+protc --bq-schema_out=path/to/out/dir foo.proto --proto_path=. --proto_path=<path_to_google_proto_folder>/src
+```
+
 ### Example
 Suppose that we have the following foo.proto.
 


### PR DESCRIPTION
Not sure if this is just standard for most people, but personally I thought the library just wasn't working because I didn't have my proto_path set up right.  Props to this [Stack Overflow question on importing descriptor.proto](http://stackoverflow.com/questions/20069295/importing-google-protobuf-descriptor-proto-in-java-protocol-buffers) for helping me to see what needed to happen.
