### PR TITLE
Fix './protos' local import to absolute import path

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,8 +30,7 @@ import (
 	"path"
 	"strings"
 
-	"./protos"
-
+	"github.com/GoogleCloudPlatform/protoc-gen-bq-schema/protos"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"


### PR DESCRIPTION
`./protos` local import causes below error.

```console
$ go install -v -x github.com/GoogleCloudPlatform/protoc-gen-bq-schema
main.go:33:2: local import "./protos" in non-local package
```

Fix to use absolute import path.