### PR TITLE
allow option w/ blank table name; don't exit non-zero

### DIFF
--- a/bq_table.proto
+++ b/bq_table.proto
@@ -35,7 +35,6 @@ extend google.protobuf.MessageOptions {
 
 
   // BigQuery message schema generation options.
-  // Indicates the message is a type of record to be stored into BigQuery.
   //
   // The field number is a globally unique id for this option, assigned by
   // protobuf-global-extension-registry@google.com
@@ -44,6 +43,8 @@ extend google.protobuf.MessageOptions {
 
 message BigQueryMessageOptions {
   // Specifies a name of table in BigQuery for the message.
+  //
+  // If not blank, indicates the message is a type of record to be stored into BigQuery.
   string table_name = 1;
 
   // If true, BigQuery field names will default to a field's JSON name,

--- a/main.go
+++ b/main.go
@@ -330,7 +330,7 @@ func convertFile(file *descriptor.FileDescriptorProto) ([]*plugin.CodeGeneratorR
 
 		tableName := opts.GetTableName()
 		if len(tableName) == 0 {
-			return nil, fmt.Errorf("table name of %s cannot be empty", msg.GetName())
+			continue
 		}
 
 		glog.V(2).Info("Generating schema for a message type ", msg.GetName())
@@ -461,6 +461,5 @@ func main() {
 		glog.Info("Succeeded to process code generator request")
 	} else {
 		glog.Info("Failed to process code generator but successfully sent the error to protoc")
-		os.Exit(1)
 	}
 }

--- a/protos/bq_table.pb.go
+++ b/protos/bq_table.pb.go
@@ -23,6 +23,8 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type BigQueryMessageOptions struct {
 	// Specifies a name of table in BigQuery for the message.
+	//
+	// If not blank, indicates the message is a type of record to be stored into BigQuery.
 	TableName string `protobuf:"bytes,1,opt,name=table_name,json=tableName,proto3" json:"table_name,omitempty"`
 	// If true, BigQuery field names will default to a field's JSON name,
 	// not its original/proto field name.


### PR DESCRIPTION
@yugui, after I tried integrating the latest version of this repo with our internal stuff, I discovered some small usability issues.

1. In my previous PR (#10), when I changed the single `table_name` string to a message, I made it so that the presence of the message means "generate a BQ table for this message". However, in my own code where I want to use those changes, I have several messages that should *not* be BQ records, but I still need to add a `use_json_names = true` option to them since they are nested in another message (which *is* a BQ record). So the logic should go back to how it was before: we generate a table when `table_name` is not blank (vs. just when `bigquery_opts` is present).
2. The code had an `os.Exit(1)` statement even when the program successfully wrote the error to stdout (in code gen response). But `protoc` does not expect this. If the plugin exits with non-zero status code, it quits, and doesn't even bother looking at the code gen response (presumably assuming that it may be incomplete/corrupt due to the failure). That means I can't actually see any error messages: they are written to the code gen response, which `protoc` is ignoring.

This fixes these issues.