### PR TITLE
Allow not specifying a package name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/utilitywarehouse/protoc-gen-bq-schema
+
+go 1.13
+
+require (
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/golang/protobuf v1.3.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/protoc-gen-bq-schema/protos"
+	"github.com/utilitywarehouse/protoc-gen-bq-schema/protos"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
@@ -315,10 +315,12 @@ func convertFile(file *descriptor.FileDescriptorProto) ([]*plugin.CodeGeneratorR
 	name := path.Base(file.GetName())
 	pkg, ok := globalPkg.relativelyLookupPackage(file.GetPackage())
 	if !ok {
-		return nil, fmt.Errorf("no such package found: %s", file.GetPackage())
+		pkg = &ProtoPackage{
+			name:     name,
+		}
 	}
 
-	response := []*plugin.CodeGeneratorResponse_File{}
+	var response []*plugin.CodeGeneratorResponse_File
 	for _, msg := range file.GetMessageType() {
 		opts, err := getBigqueryMessageOptions(msg)
 		if err != nil {


### PR DESCRIPTION
Converts the repo into a go module, makes it so that a package name isn't explicitly required. When no package is available it uses the file name as a package name. Have built and ran this locally and it appears to work for schema generation.