### PR TITLE
Added enumsasints plugin parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ message Baz {
 `protoc --bq-schema_out=. foo.proto` will generate a file named `foo/bar_table.schema`.
 The message `foo.Baz` is ignored because it doesn't have option `gen_bq_schema.bigquery_opts`.
 
+Plugin parameter `enumsasints=true` will marshal all enums into integers instead of strings: `protoc --bq-schema_out=enumsasints=true:. foo.proto`.
+
 ## License
 
 protoc-gen-bq-schema is licensed under the Apache License version 2.0.

--- a/main.go
+++ b/main.go
@@ -428,8 +428,30 @@ func convertFrom(rd io.Reader) (*plugin.CodeGeneratorResponse, error) {
 		return nil, err
 	}
 
+	commandLineParameters(req.GetParameter())
+
 	glog.V(1).Info("Converting input")
 	return convert(req)
+}
+
+func commandLineParameters(parameter string) {
+	param := make(map[string]string)
+	for _, p := range strings.Split(parameter, ",") {
+		if i := strings.Index(p, "="); i < 0 {
+			param[p] = ""
+		} else {
+			param[p[0:i]] = p[i+1:]
+		}
+	}
+
+	 for k, v := range param {
+		switch k {
+		case "enumsasints":
+			if v == "true" {
+				typeFromFieldType[descriptor.FieldDescriptorProto_TYPE_ENUM] = "INTEGER"
+			}
+		}
+	}
 }
 
 func main() {


### PR DESCRIPTION
This PR is introducing `enumsasints` plugin parameter to change the behavior of the plugin and use Integers instead of Strings in BigQuery schema to express Protobuf Enums values.

Potentially solves https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema/pull/3

Example usage:

```bash
protoc --bq-schema_out=enumsasints=true:bq_schema foo.proto
```

Implemented and tested in https://github.com/chuhlomin/protoc-gen-bq-schema:
* [foo.proto](https://github.com/chuhlomin/protoc-gen-bq-schema-example-proto/blob/master/foo.proto)
* [protoc call](https://github.com/chuhlomin/protoc-gen-bq-schema-example-proto/blob/master/.drone.yml#L11)
* [bar_table.schema](https://github.com/chuhlomin/protoc-gen-bq-schema-example-bq/blob/master/foo/bar_table.schema)