### PR TITLE
Add protoc Param --bq-schema_opt=single-message

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,13 +44,14 @@ jobs:
       run: |
          protoc -I. -Iexamples --plugin=./protoc-gen-bq-schema --bq-schema_out=examples examples/foo.proto
          protoc -I. -Iexamples --plugin=./protoc-gen-bq-schema --bq-schema_out=examples examples/foo-proto3.proto
+         protoc -I. -Iexamples --plugin=./protoc-gen-bq-schema --bq-schema_out=examples --bq-schema_opt=single-message examples/single_message.proto
     - name: Verify examples are working
       run: |
         if [ -n "$(git status --porcelain)" ]; then
           git status # Show the files that failed to pass the check.
           exit 1
         fi
-   
+
   test:
     name: Root tests
     runs-on: ubuntu-latest
@@ -58,7 +59,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.15'
+          go-version: '^1.16'
       - name: Check code
         uses: actions/checkout@v2
       - run: go test -v

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ So you can reuse existing data definitions in .proto for BigQuery with this plug
  go get github.com/GoogleCloudPlatform/protoc-gen-bq-schema
 
 ## Usage
- protoc --bq-schema\_out=path/to/outdir foo.proto
+ protoc --bq-schema\_out=path/to/outdir \[--bq-schema_opt=single-message\] foo.proto
 
 `protoc` and `protoc-gen-bq-schema` commands must be found in $PATH.
 
@@ -65,6 +65,9 @@ message Baz {
 
 `protoc --bq-schema_out=. foo.proto` will generate a file named `foo/bar_table.schema`.
 The message `foo.Baz` is ignored because it doesn't have option `gen_bq_schema.bigquery_opts`.
+
+`protoc --bq-schema_out=. --bq-schema_opt=single-message foo.proto` will generate a file named `foo/foo.schema`.
+The message `foo.Baz` is also ignored because it is not the first message in the file.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ message Baz {
 `protoc --bq-schema_out=. foo.proto` will generate a file named `foo/bar_table.schema`.
 The message `foo.Baz` is ignored because it doesn't have option `gen_bq_schema.bigquery_opts`.
 
-`protoc --bq-schema_out=. --bq-schema_opt=single-message foo.proto` will generate a file named `foo/foo.schema`.
+`protoc --bq-schema_out=. --bq-schema_opt=single-message single_message.proto` will generate a file named `foo/single_message.schema`.
 The message `foo.Baz` is also ignored because it is not the first message in the file.
 
 ## License

--- a/examples/foo/single_message.schema
+++ b/examples/foo/single_message.schema
@@ -1,0 +1,37 @@
+[
+ {
+  "name": "a",
+  "type": "INTEGER",
+  "mode": "REQUIRED",
+  "description": "Description of field a -- this is an int32"
+ },
+ {
+  "name": "b",
+  "type": "RECORD",
+  "mode": "NULLABLE",
+  "description": "Nested b structure",
+  "fields": [
+   {
+    "name": "a",
+    "type": "INTEGER",
+    "mode": "REPEATED"
+   }
+  ]
+ },
+ {
+  "name": "c",
+  "type": "STRING",
+  "mode": "REPEATED",
+  "description": "Repeated c string"
+ },
+ {
+  "name": "wkt1",
+  "type": "INTEGER",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "wkt2",
+  "type": "TIMESTAMP",
+  "mode": "NULLABLE"
+ }
+]

--- a/examples/single_message.proto
+++ b/examples/single_message.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+package foo;
+
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/timestamp.proto";
+
+message Bar {
+  message Nested {
+    repeated int32 a = 1;
+  }
+
+  // Description of field a -- this is an int32
+  required int32 a = 1;
+
+  // Nested b structure
+  optional Nested b = 2;
+
+  // Repeated c string
+  repeated string c = 3;
+
+  optional google.protobuf.Int32Value wkt1 = 11;
+  optional google.protobuf.Timestamp wkt2 = 12;
+}
+
+message Baz {
+  required int32 a = 1;
+}


### PR DESCRIPTION
adding a `protoc` param `--bq-schema_opt=single-message` to tell `protoc-gen-bq-schema` treating each proto files only contains one top-level message type.

if a file contains no message types, then the param simply does nothing.
if a file contains more than one message type, then only the first message type will be processed. in that case, the table names will follow the proto file names (e.g. `foo.proto` becomes `foo.schema`).