### PR TITLE
Add option use-json-names to allow using json_name globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ go install github.com/GoogleCloudPlatform/protoc-gen-bq-schema@latest
 ```
 
 ## Usage
- protoc --bq-schema\_out=path/to/outdir \[--bq-schema_opt=single-message\] foo.proto
+ protoc --bq-schema\_out=path/to/outdir \[--bq-schema_opt=single-message,use-json-names\] foo.proto
 
 `protoc` and `protoc-gen-bq-schema` commands must be found in $PATH.
 
@@ -71,6 +71,9 @@ The message `foo.Baz` is ignored because it doesn't have option `gen_bq_schema.b
 
 `protoc --bq-schema_out=. --bq-schema_opt=single-message single_message.proto` will generate a file named `foo/single_message.schema`.
 The message `foo.Baz` is also ignored because it is not the first message in the file.
+
+`protoc --bq-schema_out=. --bq-schema_opt=use-json-names foo.proto` will generate a schema whose fields are named using `json_name`.
+This is equivalent to tagging every message as `use_json_names = true` and provided for convenience.
 
 
 ### Support for PolicyTags


### PR DESCRIPTION
I use this project to keeping a proto definition to a BigQuery table. The proto has many nested messages inside.
I use jsonpb.Marshaler to generate json messages which are imported into the BigQuery table. So I tried to use `json_name` for BigQuery fields as well, but I found that I need to tag every nested messages referenced in the proto with  `option (gen_bq_schema.bigquery_opts).json_name = true;`.
It's kind of error-prone, since the BigQuery schema generation isn't the only usage of the proto, and there's a possibility that anyone creates a new proto without adding `json_name = true`.
So I wanted to turn it on globally, but I couldn't find an easy way to do so other than adding a global option. Hence this PR.

I'm new to the project. Any suggestions to improve my change will be appreciated.
Thank you for the maintenance effort.