### PR TITLE
Add optional support for proto3 fields

### DIFF
--- a/examples/foo/test_table.schema
+++ b/examples/foo/test_table.schema
@@ -15,7 +15,7 @@
   "mode": "NULLABLE",
   "policyTags": {
    "names": [
-    "public
+    "public"
    ]
   }
  },
@@ -40,5 +40,10 @@
     "mode": "NULLABLE"
    }
   ]
+ },
+ {
+  "name": "optional_c",
+  "type": "STRING",
+  "mode": "NULLABLE"
  }
 ]

--- a/examples/test_table.proto
+++ b/examples/test_table.proto
@@ -30,4 +30,6 @@ message TestTable{
     message EmptyMessage {}
 
     repeated EmptyMessage hasMessage = 4;
+
+    optional string optional_c = 5;
 }

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/golang/glog v1.0.0
 	github.com/golang/protobuf v1.5.2
-	google.golang.org/protobuf v1.28.0
+	google.golang.org/protobuf v1.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,5 +9,5 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	descriptor "google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 var (
@@ -391,7 +392,9 @@ func Convert(req *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, e
 		generateTargets[file] = true
 	}
 
-	res := &plugin.CodeGeneratorResponse{}
+	res := &plugin.CodeGeneratorResponse{
+		SupportedFeatures: proto.Uint64(uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)),
+	}
 	for _, file := range req.GetProtoFile() {
 		for msgIndex, msg := range file.GetMessageType() {
 			glog.V(1).Infof("Loading a message type %s from package %s", msg.GetName(), file.GetPackage())


### PR DESCRIPTION
With `nullable` as the default this should be ok for **proto3** optional fields.
Added the flag that says **optional** is supported for **proto3** field definitions.

Also a small fixup in one of the sample outputs.