### PR TITLE
Add protoc Param --bq-schema_opt=type-override=field_name.field_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ go install github.com/GoogleCloudPlatform/protoc-gen-bq-schema@latest
 ```
 
 ## Usage
- protoc --bq-schema\_out=path/to/outdir \[--bq-schema_opt=single-message\] foo.proto
+
+providing `single-message` parameter tells protoc-gen-bq-schema to treat each proto files only contains one top-level type.
+```sh
+protoc --bq-schema\_out=path/to/outdir \[--bq-schema_opt=single-message\] foo.proto
+```
+When using `single-message` you can passing the type overrides as a command line parameter as well. The parameter should be a string where each field name and type pair is separated by a dot.
+```sh
+protoc --bq-schema\_out=path/to/outdir \[--bq-schema_opt=single-message\] \[--bq-schema_opt=type-override=field_name.field_type\] foo.proto
+```
+
 
 `protoc` and `protoc-gen-bq-schema` commands must be found in $PATH.
 


### PR DESCRIPTION
Base on the `--bq-schema_opt=single-message`, add additional `--bq-schema_opt=type-override=field_name.field_type` to tell `protoc-gen-bq-schema` to specify certain field's `TypeOverride` field options.

If the `single-message` doesn't be specify, this will not work as well.
By add this param, can minimize the use of imports.

The primary motivation for this feature is to facilitate the maintenance of consistent Pub/Sub Schemas and BigQuery schemas using the same .proto files. In certain scenarios, such as when using .proto files to create Pub/Sub Schemas, importing additional files (like bq_field.proto) is not permissible. This enhancement circumvents the need for such imports, simplifying the workflow and making schema management more streamlined, especially for users who need to maintain compatibility across different systems using Protocol Buffers.