### PR TITLE
Truncate description if more than 1024 characters

### DIFF
--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -171,7 +171,7 @@ func convertField(
 	}
 
 	if len(field.Description) > 1024 {
-		field.Description = field.Description[:1024]
+		field.Description = field.Description[:1021] + "..."
 	}
 
 	if field.Type != "RECORD" {

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -170,6 +170,10 @@ func convertField(
 		}
 	}
 
+	if len(field.Description) > 1024 {
+		field.Description = field.Description[:1024]
+	}
+
 	if field.Type != "RECORD" {
 		return field, nil
 	}


### PR DESCRIPTION
BigQuery has a limit of 1024 characters on a field description:
```
BigQuery error in update operation: The description for field <field-name> is too long. The maximum length is 1024 characters.
```
This PR truncates the description and adds `...` if it is ends up more than 1024 characters