### PR TITLE
Tidy up Makefile and go.sum files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ $(BQ_PLUGIN): $(PROTO_GENFILES) goprotobuf glog
 	go build -o $@
 
 $(PROTO_GENFILES): $(PROTO_SRC) $(GO_PLUGIN)
-	protoc -I. -Ivendor/protobuf --plugin=$(GO_PLUGIN) --go_out=$(PKGMAP):protos --go_opt=paths=source_relative $(PROTO_SRC)
+	protoc -I. --plugin=$(GO_PLUGIN) --go_out=$(PKGMAP):protos --go_opt=paths=source_relative $(PROTO_SRC)
 
 goprotobuf:
 	go get $(PROTO_PKG)
@@ -50,6 +50,6 @@ realclean: distclean
 	rm -f $(PROTO_GENFILES)
 
 examples: $(BQ_PLUGIN)
-	protoc -I. -Ivendor/protobuf --plugin=$(BQ_PLUGIN) --bq-schema_out=examples $(EXAMPLES_PROTO)
+	protoc -I. --plugin=$(BQ_PLUGIN) --bq-schema_out=examples $(EXAMPLES_PROTO)
 
 .PHONY: goprotobuf glog

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/golang/glog v1.2.0 h1:uCdmnmatrKCgMBlM4rMuJZWOkPDqdbZPnrMXDY4gI68=
-github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/glog v1.2.1 h1:OptwRhECazUx5ix5TTWC3EZhsZEHWcYWY4FQHTIubm4=
 github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=


### PR DESCRIPTION
Small fix to get CI green ([failure job on main](https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema/actions/runs/8722154740/)), following #48. Need to run `go mod tidy` when bumping deps to avoid a change diff.

Also noticed there's no vendoring, so the `-Ivendor/protobuf` is unnecessary.