### PR TITLE
Update duration type mapping in convert.go

### DIFF
--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -27,7 +27,7 @@ var (
 		".google.protobuf.BoolValue":   "BOOLEAN",
 		".google.protobuf.StringValue": "STRING",
 		".google.protobuf.BytesValue":  "BYTES",
-		".google.protobuf.Duration":    "STRING",
+		".google.protobuf.Duration":    "INTERVAL",
 		".google.protobuf.Timestamp":   "TIMESTAMP",
 	}
 	typeFromFieldType = map[descriptor.FieldDescriptorProto_Type]string{

--- a/pkg/converter/plugin_test.go
+++ b/pkg/converter/plugin_test.go
@@ -416,7 +416,7 @@ func TestWellKnownTypes(t *testing.T) {
 				{ "name": "bool", "type": "BOOLEAN", "mode": "NULLABLE" },
 				{ "name": "str", "type": "STRING", "mode": "NULLABLE" },
 				{ "name": "bytes", "type": "BYTES", "mode": "NULLABLE" },
-				{ "name": "du", "type": "STRING", "mode": "NULLABLE" },
+				{ "name": "du", "type": "INTERVAL", "mode": "NULLABLE" },
 				{ "name": "t", "type": "TIMESTAMP", "mode": "NULLABLE" }
 			]`,
 		})


### PR DESCRIPTION
Per https://cloud.google.com/bigquery/docs/write-api#data_type_conversions, the duration protobuf type should be mapped to INTERVAL type on BigQuery side.