### PR TITLE
Upgrade to a /v2 module and bump deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/GoogleCloudPlatform/protoc-gen-bq-schema
+module github.com/GoogleCloudPlatform/protoc-gen-bq-schema/v2
 
-go 1.16
+go 1.21
 
 require (
-	github.com/golang/glog v1.2.1
-	google.golang.org/protobuf v1.33.0
+	github.com/golang/glog v1.2.3
+	google.golang.org/protobuf v1.35.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
-github.com/golang/glog v1.2.1 h1:OptwRhECazUx5ix5TTWC3EZhsZEHWcYWY4FQHTIubm4=
-github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/golang/glog v1.2.3 h1:oDTdz9f5VGVVNGu/Q7UXKWYsD0873HXLHdJUNBsSEKM=
+github.com/golang/glog v1.2.3/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8io=
+google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleCloudPlatform/protoc-gen-bq-schema/pkg/converter"
+	"github.com/GoogleCloudPlatform/protoc-gen-bq-schema/v2/pkg/converter"
 	"github.com/golang/glog"
 	"google.golang.org/protobuf/proto"
 	plugin "google.golang.org/protobuf/types/pluginpb"

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/GoogleCloudPlatform/protoc-gen-bq-schema/protos"
+	"github.com/GoogleCloudPlatform/protoc-gen-bq-schema/v2/protos"
 	"github.com/golang/glog"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"


### PR DESCRIPTION
When tagging a v2, we should also update the Go module itself to a /v2 by suffixing.

Also updated the dependencies.

You should be able to merge this, tag a `v2.0.1` and then users will be able to correctly `go install ...`