### PR TITLE
Support proto editions

### DIFF
--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -408,7 +408,9 @@ func Convert(req *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, e
 	}
 
 	res := &plugin.CodeGeneratorResponse{
-		SupportedFeatures: proto.Uint64(uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)),
+		SupportedFeatures: proto.Uint64(uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL | plugin.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS)),
+		MinimumEdition:    proto.Int32(int32(descriptor.Edition_EDITION_PROTO2)),
+		MaximumEdition:    proto.Int32(int32(descriptor.Edition_EDITION_MAX)),
 	}
 	for _, file := range req.GetProtoFile() {
 		for msgIndex, msg := range file.GetMessageType() {


### PR DESCRIPTION
Update CodeGeneratorResponse to indicate support for editions and specify min and max editions.

I tested against an `editions = 2023` file and it seems to generate the schema just fine.