### PR TITLE
Handle packages with no messages defined

### DIFF
--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -319,6 +319,10 @@ func convertMessageType(
 }
 
 func convertFile(file *descriptor.FileDescriptorProto) ([]*plugin.CodeGeneratorResponse_File, error) {
+	if len(file.GetMessageType()) == 0 {
+		return nil, nil
+	}
+
 	name := path.Base(file.GetName())
 	pkg, ok := globalPkg.relativelyLookupPackage(file.GetPackage())
 	if !ok {


### PR DESCRIPTION
# Description

Exit from `convertFile` early if no messages are defined in the file, before looking up the package.

# Bug Report

`protoc-gen-bq-schema` fails when processing packages with no messages, returning the error:

```
Failure: plugin protoc-gen-bq-schema: Failed to convert x/y/z.proto: no such package found: x.y
```

The problem is that the plugin only registers types for files that have messages:
https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema/blob/74582ff873c5854a3d3341446b9bf30f201b63c0/pkg/converter/convert.go#L425-L430

Then `convertFile` attempts to lookup the package before iterating over the messages, but that package was never registered:
https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema/blob/74582ff873c5854a3d3341446b9bf30f201b63c0/pkg/converter/convert.go#L323-L326